### PR TITLE
make protoc executable by others

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
 # protoc
 RUN curl -fsSLO https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip \
  && unzip "protoc-$PROTOC_VERSION-linux-x86_64.zip" -d protoc \
+ && chmod -R o+rx protoc/ \
  && mv protoc/bin/* /usr/local/bin/ \
  && mv protoc/include/* /usr/local/include/ \
  && go get -u github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
hi,

in the current image the `protoc` command is only executable for `root`. if your start the image as another user, you cannot use this command.

the bundled libraries are also only accessible for `root` so if you want to 
~~~
import "google/protobuf/timestamp.proto";
~~~
you also need root privileges to access the include directories in the image.

this PR fixes the rights, so others are able to read and execute.