### PR TITLE
Try to auto-determine injected version flag.

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -2,7 +2,7 @@
 SHA := $(shell git rev-parse --short=8 HEAD)
 GITVERSION := $(shell git describe --long --all)
 BUILDDATE := $(shell GO111MODULE=off go run ${COMMONDIR}/time.go)
-VERSION := $(or ${VERSION},devel)
+VERSION := $(or ${VERSION},$(shell git describe --tags --exact-match 2> /dev/null || git symbolic-ref -q --short HEAD || git rev-parse --short HEAD))
 CGO_ENABLED := $(or ${CGO_ENABLED},0)
 GO := go
 GOSRC = $(shell find . -not \( -path vendor -prune \) -type f -name '*.go')


### PR DESCRIPTION
Currently, all builds have the "devel" version because no-one sets the VERSION for an individual build. This commit auto-determines the version from git (tag -> branch -> sha).