### PR TITLE
allow local usage of act and support actions in forks

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+# settings used for local testing with replacements
+-P ubuntu-latest=ulrichschreiner/go-web-dev

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -10,8 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Build the Docker images
+    - name: Build the latest Docker image
       run: |
-        docker login -u metalstackci -p ${{ secrets.DOCKER_HUB_TOKEN }}
         docker build -t metalstack/builder .
-        docker push metalstack/builder
+    - name: Push the latest image
+      run: |
+        if [ "${{ secrets.DOCKER_HUB_TOKEN }}" != "undefined" -a "${{secrets.DOCKER_HUB_TOKEN }}" != "" ]; then
+          docker login -u metalstackci -p ${{ secrets.DOCKER_HUB_TOKEN }}
+          docker push metalstack/builder
+        fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Build the Docker images
+    - name: Build and push the released Docker images
       run: |
-        docker login -u metalstackci -p ${{ secrets.DOCKER_HUB_TOKEN }}
-        docker build -t metalstack/builder:${{ github.ref }} .
-        docker push metalstack/builder:${{ github.ref }}
+        if [ "${{ secrets.DOCKER_HUB_TOKEN }}" != "undefined" -a "${{secrets.DOCKER_HUB_TOKEN }}" != "" ]; then
+          docker login -u metalstackci -p ${{ secrets.DOCKER_HUB_TOKEN }}
+          docker build -t metalstack/builder:${{ github.ref }} .
+          docker push metalstack/builder:${{ github.ref }}
+        fi


### PR DESCRIPTION
this PR allows me to use [act](https://github.com/nektos/act) for local testing of the actions. It also allows to enable actions in forks because in both cases the login/push of the image will not be executed.

please note that i put my own image in the `.actrc` file as a replacement for `ubuntu-latest` because the actions need a installed `docker` command. it can be replaced with any other image you like.