### PR TITLE
Update swagger from 0.19 -> 0.23 which creates different clients, als…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.13-buster as builder
 
 ENV COMMONDIR=/common \
-    VERSION_GO_SWAGGER=0.19.0 \
-    VERSION_GOLANGCI_LINT=1.23.2 \
-    PROTOC_VERSION=3.11.3
+    VERSION_GO_SWAGGER=0.23.0 \
+    VERSION_GOLANGCI_LINT=1.24.0 \
+    PROTOC_VERSION=3.11.4
 
 # swagger and required packages
 RUN apt-get update \

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -83,14 +83,10 @@ test-ci:
 test-integration:
 	CGO_ENABLED=1 $(GO) test -tags=integration -p 1 -cover ./...
 
-.PHONY: swaggercheck
-swaggercheck:
-	@hash swagger 2>/dev/null || (echo "swagger is required but not available in current PATH. See https://github.com/go-swagger/go-swagger/releases/."; exit 1)
-
 .PHONY: swaggergenerate
-swaggergenerate: swaggercheck
+swaggergenerate:
 	echo $(SWAGGERSPEC)
-	GO111MODULE=off swagger generate client -f $(SWAGGERSPEC) -t $(SWAGGERTARGET) --skip-validation
+	GO111MODULE=off docker run -it --user $$(id -u):$$(id -g) --rm -v ${PWD}:/work metalstack/builder swagger generate client -f $(SWAGGERSPEC) -t $(SWAGGERTARGET) --skip-validation
 
 # Static code analysis
 .PHONY: check


### PR DESCRIPTION
…o make generate-client always uses swagger from builder image.

This is the start of swagger 0.23, which requires to make modifications in all clients !