### PR TITLE
Update to go 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-buster as builder
+FROM golang:1.14.2-buster as builder
 
 ENV COMMONDIR=/common \
     VERSION_GO_SWAGGER=0.19.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.13-buster as builder
+FROM golang:1.14-buster as builder
 
 ENV COMMONDIR=/common \
     VERSION_GO_SWAGGER=0.19.0 \
-    VERSION_GOLANGCI_LINT=1.23.2 \
-    PROTOC_VERSION=3.11.3
+    VERSION_GOLANGCI_LINT=1.25.0 \
+    PROTOC_VERSION=3.11.4
 
 # swagger and required packages
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.14.2-buster as builder
+FROM golang:1.14.4-buster as builder
 
 ENV COMMONDIR=/common \
     VERSION_GO_SWAGGER=0.19.0 \
-    VERSION_GOLANGCI_LINT=1.25.1 \
-    PROTOC_VERSION=3.11.4
+    VERSION_GOLANGCI_LINT=1.27.0 \
+    PROTOC_VERSION=3.12.3
 
 # swagger and required packages
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.14.2-buster as builder
 
 ENV COMMONDIR=/common \
     VERSION_GO_SWAGGER=0.19.0 \
-    VERSION_GOLANGCI_LINT=1.25.0 \
+    VERSION_GOLANGCI_LINT=1.25.1 \
     PROTOC_VERSION=3.11.4
 
 # swagger and required packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.14.6-buster as builder
+FROM golang:1.14.7-buster as builder
 
 ENV COMMONDIR=/common \
     VERSION_GO_SWAGGER=0.19.0 \
-    VERSION_GOLANGCI_LINT=1.28.3 \
+    VERSION_GOLANGCI_LINT=1.30.0 \
     VERSION_JQ=1.6 \
-    VERSION_PROTOC=3.12.3
+    VERSION_PROTOC=3.12.4
 
 # golangci-lint
 RUN curl -fsSLO https://github.com/golangci/golangci-lint/releases/download/v${VERSION_GOLANGCI_LINT}/golangci-lint-${VERSION_GOLANGCI_LINT}-linux-amd64.tar.gz \

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -83,14 +83,10 @@ test-ci:
 test-integration:
 	CGO_ENABLED=1 $(GO) test -tags=integration -p 1 -cover ./...
 
-.PHONY: swaggercheck
-swaggercheck:
-	@hash swagger 2>/dev/null || (echo "swagger is required but not available in current PATH. See https://github.com/go-swagger/go-swagger/releases/."; exit 1)
-
 .PHONY: swaggergenerate
-swaggergenerate: swaggercheck
+swaggergenerate:
 	echo $(SWAGGERSPEC)
-	GO111MODULE=off swagger generate client -f $(SWAGGERSPEC) -t $(SWAGGERTARGET) --skip-validation
+	GO111MODULE=off docker run -it --user $$(id -u):$$(id -g) --rm -v ${PWD}:/work metalstack/builder swagger generate client -f $(SWAGGERSPEC) -t $(SWAGGERTARGET) --skip-validation
 
 # Static code analysis
 .PHONY: check

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Use this repository in your Makefile by including it:
 
-~~~Makefile
+```Makefile
 BINARY := metal-api
 MAINMODULE := <your package>
 COMMONDIR := $(or ${COMMONDIR},../../common)
@@ -12,7 +12,7 @@ COMMONDIR := $(or ${COMMONDIR},../../common)
 include $(COMMONDIR)/Makefile.inc
 
 release:: all ;
-~~~
+```
 
 You have to:
 
@@ -23,7 +23,7 @@ You have to:
   and multistage builds can set this path to another location than on your local pc.
 - overwrite the `release` target (note the two colons after the target name). Normally you should set
   this to the `all` which compiles your go code. But sometimes you want to do something before compiling
-  (generate code, etcpp.).
+  (generate code, etc.).
 
 Now you can simply `make` to build a binary
 
@@ -31,9 +31,9 @@ Now you can simply `make` to build a binary
 
 You can use the image as a base builder image in your own Dockerfile:
 
-~~~Dockerfile
+```Dockerfile
 FROM metalstack/builder:latest as builder
-~~~
+```
 
 This base image wants you to have a `go.mod` and a `Makefile` where the default target
 creates the binary. This binary will be located in the path `/work/bin/...`.


### PR DESCRIPTION
Update:
- go from 1.13 -> 1.14 for all our projects using builder
- protoc from 3.11.3 -> 3.11.4
- golancilint from 1.23 -> 1.25

I will close my PR #4 which also updates swagger, we should this do in a separate step.