### PR TITLE
Update to golangci-lint v1.26.0.

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,19 @@
+name: Build image from pull request
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build and push the released Docker images
+      run: |
+        if [ "${{ secrets.DOCKER_HUB_TOKEN }}" != "undefined" -a "${{secrets.DOCKER_HUB_TOKEN }}" != "" ]; then
+          docker login -u metalstackci -p ${{ secrets.DOCKER_HUB_TOKEN }}
+          docker build -t metalstack/builder:pr-${{ github.ref }} .
+          docker push metalstack/builder:pr-${{ github.ref }}
+        fi

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -14,6 +14,7 @@ jobs:
       run: |
         if [ "${{ secrets.DOCKER_HUB_TOKEN }}" != "undefined" -a "${{secrets.DOCKER_HUB_TOKEN }}" != "" ]; then
           docker login -u metalstackci -p ${{ secrets.DOCKER_HUB_TOKEN }}
-          docker build -t metalstack/builder:pr-${{ github.ref }} .
-          docker push metalstack/builder:pr-${{ github.ref }}
+          # pull request images are prefixed with 'pr' to prevent them from overriding released images
+          docker build -t metalstack/builder:pr-${GITHUB_HEAD_REF##*/} .
+          docker push metalstack/builder:pr-${GITHUB_HEAD_REF##*/}
         fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,6 @@ jobs:
       run: |
         if [ "${{ secrets.DOCKER_HUB_TOKEN }}" != "undefined" -a "${{secrets.DOCKER_HUB_TOKEN }}" != "" ]; then
           docker login -u metalstackci -p ${{ secrets.DOCKER_HUB_TOKEN }}
-          docker build -t metalstack/builder:${{ github.ref }} .
-          docker push metalstack/builder:${{ github.ref }}
+          docker build -t metalstack/builder:${GITHUB_HEAD_REF##*/} .
+          docker push metalstack/builder:${GITHUB_HEAD_REF##*/}
         fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.13-buster as builder
 
 ENV COMMONDIR=/common \
     VERSION_GO_SWAGGER=0.19.0 \
-    VERSION_GOLANGCI_LINT=1.23.2 \
+    VERSION_GOLANGCI_LINT=1.26.0 \
     PROTOC_VERSION=3.11.3
 
 # golangci-lint


### PR DESCRIPTION
The newer version resolves some issues with a bad error message when downloading go deps goes wrong.