### PR TITLE
Update go to 1.16.6, linter to 1.14.1 and protoc to 3.17.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.16.5-buster as builder
+FROM golang:1.16.6-buster as builder
 
 ENV COMMONDIR=/common \
     IN_BUILDER=true \
     VERSION_GO_SWAGGER=0.27.0 \
-    VERSION_GOLANGCI_LINT=1.40.1 \
+    VERSION_GOLANGCI_LINT=1.41.1 \
     VERSION_JQ=1.6 \
-    VERSION_PROTOC=3.17.2 \
+    VERSION_PROTOC=3.17.3 \
     VERSION_DOCKER_MAKE=v0.3.6 \
     XDG_CACHE_HOME=/tmp/.cache
 


### PR DESCRIPTION
Fix for CVE-2021-34558