### PR TITLE
in case incompatible modules are in the dependencies, this is required

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -69,7 +69,7 @@ vendor:
 
 .PHONY: tidy
 tidy:
-	$(GO) mod tidy
+	$(GO) mod tidy -compat=1.17
 
 .PHONY: test
 test:


### PR DESCRIPTION
From cloud-api build:

```
go mod tidy: error loading go 1.16 module graph: github.com/metal-stack/masterdata-api@v0.8.11 requires
	github.com/docker/distribution@v2.8.0+incompatible: reading https://gomods.fi-ts.io/github.com/docker/distribution/@v/v2.8.0+incompatible.mod: 404 Not Found
If reproducibility with go 1.16 is not needed:
	go mod tidy -compat=1.17
For other options, see:
	https://golang.org/doc/modules/pruning
make: *** [/common/Makefile.inc:72: tidy] Error 1
```