### PR TITLE
Update swagger to v0.30.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.19.5-buster as builder
 
 ENV COMMONDIR=/common \
     IN_BUILDER=true \
-    VERSION_GO_SWAGGER=0.30.3 \
+    VERSION_GO_SWAGGER=0.30.4 \
     VERSION_GOLANGCI_LINT=1.50.1 \
     VERSION_JQ=1.6 \
     VERSION_PROTOC=3.20.1 \


### PR DESCRIPTION
Which creates the following diff in metal-go: https://github.com/metal-stack/metal-go/pull/110

Looks fine for me as it only adds more Response Defaults for Created and Conflict, and moves one Response